### PR TITLE
Adicionado sistema de login com o allauth

### DIFF
--- a/app/settings.sample.py
+++ b/app/settings.sample.py
@@ -37,7 +37,14 @@ DJANGO_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
     'pipeline',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.facebook',
+    'allauth.socialaccount.providers.github',
+    'allauth.socialaccount.providers.google',
 ]
 
 MODULES_APP = [
@@ -144,3 +151,15 @@ PIPELINE = {
         },
     },
 }
+
+
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+    'allauth.account.auth_backends.AuthenticationBackend',
+)
+
+ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_USERNAME_REQUIRED = False
+ACCOUNT_AUTHENTICATION_METHOD = "email"
+# SITE ID
+SITE_ID = 1

--- a/app/urls.py
+++ b/app/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url, include
 from django.contrib import admin
 
 urlpatterns = [
+    url(r'^accounts/', include('allauth.urls')),
     url(r'^admin/', admin.site.urls),
     url(r'^', include('modules.board.urls')),
 ]

--- a/deploy/requirements-dev.txt
+++ b/deploy/requirements-dev.txt
@@ -3,6 +3,7 @@ backports.shutil-get-terminal-size==1.0.0
 coverage==4.1
 decorator==4.0.10
 Django==1.9.7
+django-allauth==0.25.2
 django-pipeline==1.6.8
 gnureadline==6.3.3
 ipython==4.2.0


### PR DESCRIPTION
Foi adicioando o biblioteca Django-allauth como facilitador para autenticação de usuários.
Com esta biblioteca podemos habilitar o cadastro e autenticação por meio do protocolo OAuth utilizando provedores como Facebook, Github e Google Accounts.
